### PR TITLE
Add `through` devDependencies & fix `options` doesn't work as documentation describes

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,13 @@ function stringify(content) {
 	stringified_content = stringified_content.replace(/(.+)$/gm, '$1" +');
 	stringified_content = stringified_content.replace(/\+$/, '');
 
-	return 'module.exports = '+stringified_content+';\n';
+	return 'module.exports = ' + stringified_content + ';\n';
 }
 
 /**
  * Creates the
- * @param   {object}    options
- * @param   {object}    options.extensions
+ * @param   {object | array}    options
+ * @param   {object}            options.extensions
  * @returns {stream}
  */
 module.exports = function(options) {
@@ -36,8 +36,12 @@ module.exports = function(options) {
 		'.tpl'
 	];
 
-	if (options && options.extensions) {
-		extensions = options.extensions;
+	if (options) {
+		if (Object.prototype.toString.call(options) === '[object Array]') {
+			extensions = options;
+		} else if(options.extensions) {
+			extensions = options.extensions;
+		}
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./index.js",
   "author": "John Postlethwait <john.postlethwait@gmail.com>",
   "contributors": [
-	  "James Newell <james@digitaledgeit.com.au>"
+    "James Newell <james@digitaledgeit.com.au>",
+    "Livoras <livoras@163.com>"
   ],
   "website": "http://johnpostlethwait.github.com/stringify/",
   "keywords": [
@@ -20,13 +21,16 @@
     "type": "git",
     "url": "git://github.com/JohnPostlethwait/stringify.git"
   },
-  "engines" : {
-    "node" : "*"
+  "engines": {
+    "node": "*"
   },
   "licenses": [
     {
       "name": "MIT",
       "url": "http://opensource.org/licenses/mit-license.php"
     }
-  ]
+  ],
+  "devDependencies": {
+    "through": "~2.3.4"
+  }
 }


### PR DESCRIPTION
Hi, there. I really like your work and it does help!

I updated the source code and I hope the works I did would make it better.

Here are the major updates of this PR:
### 1. add `through` dependency to `package.json`

The `index.js` depends on `through`, but it doesn't apparent in `package.json`. This will cause an error of module is not found while runtime.
### 2. fix `options` of `stringify` function doesn't work as documentation describes

According to the [docs](https://github.com/JohnPostlethwait/stringify#usage), code below will work with the `.hbs` extension.

``` javascript
var browserify = require('browserify'),
    stringify = require('stringify');

var bundle = browserify()
    .transform(stringify(['.hbs', '.handlebars']))
    .addEntry('my_app_main.js');

app.use(bundle);
```

But the `index.js` code indicates that the `stringify` function accepts actually an object `options` containing `extensions` instead of merely an array. I updated `index.js` to make it work with two kind of options:

```
// with object
var bundle = browserify()
    .transform(stringify({
        extensions: ['.hbs', '.handlebars']
     })).addEntry('my_app_main.js');

// with array
var bundle = browserify()
    .transform(stringify(['.hbs', '.handlebars']))
    .addEntry('my_app_main.js');
```

PS: Adding tests would be reliable.

Hope it helps.
