### PR TITLE
Added support for command line usage (100% statements coverage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install stringify
 
 ## Usage ##
 
-Setup Browserify to use this middleware in your app:
+Use it directly from the command line `browserity -t stringify myfile.js` or setup Browserify to use this middleware in your app:
 
 ```javascript
 var browserify = require('browserify'),

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "James Newell <james@digitaledgeit.com.au>",
     "Kevin Ingersoll <kingersoll@gmail.com>",
     "Livoras <livoras@163.com>",
-    "Sébastien David <sebastien.david.1983@gmail.com>"
+    "Sébastien David <sebastien.david.1983@gmail.com>",
+    "Kenneth Skovhus <kenneth.skovhus@gmail.com>"
   ],
   "website": "http://johnpostlethwait.github.com/stringify/",
   "keywords": [
@@ -34,6 +35,7 @@
   ],
   "dependencies": {
     "html-minifier": "^0.6.9",
+    "stream-spec": "~0.3.5",
     "through": "^2.3.4"
   },
   "devDependencies": {

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -147,7 +147,6 @@ module.exports = function (file, options) {
    * @returns {stream}
    */
   function browserifyTransform (file) {
-    options = options || {};
     var extensions = getExtensions(options);
 
     if (!hasStringifiableExtension(file, extensions)) {
@@ -170,7 +169,9 @@ module.exports = function (file, options) {
   }
 
   if (typeof file !== 'string') {
-    // Factory: return function (first argument is options)
+    // Factory: return a function.
+    // Set options variable here so it is ready for when browserifyTransform
+    // is called. Note: first argument is the options.
     options = file;
     return browserifyTransform;
   } else {


### PR DESCRIPTION
I've added support for the browserify command line usage e.g. `browserify -t stringify`. The tests shows that everything still works for the normal middleware usage, where the module returns a factory function. But as I'm not using `stringify` as a middleware please verify that this still works.

This solves #8 and https://github.com/substack/node-browserify/issues/823

As a bonus the code coverage is increased from 90% to 100%. : ) 