### PR TITLE
SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,7 @@
   "engines": {
     "node": "*"
   },
-  "licenses": [
-    {
-      "name": "MIT",
-      "url": "http://opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "html-minifier": "^0.6.9",
     "stream-spec": "~0.3.5",


### PR DESCRIPTION
The `licenses` property is deprecated and superceded by `license` which expects a valid SPDX license identifier. This small change cleans up npm warnings and helps license auditing tools like [nlv](https://www.npmjs.com/package/node-license-validator).

See:
- https://docs.npmjs.com/files/package.json#license
- http://spdx.org/licenses/