### PR TITLE
command line extension array support

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -73,6 +73,9 @@ function getExtensions (options) {
     } else if (options.extensions) {
       extensions = options.extensions;
     }
+    else if( options.exts ) {
+      extensions = options.exts._;
+    }
   }
 
   // Lowercase all file extensions for case-insensitive matching.


### PR DESCRIPTION
 browserify -t [ stringify --exts [.html .hbs] ] -d src/scripts/ -o dist/js/bundle.js

I urgently needed extensions in command line.
It this version, you can pass an array of extensions.
It look like theres an internal problem into browserify with the "extensions" arugment name.
Changed it to 'exts' for the command line usage

Cheers