### PR TITLE
Correcting command line support for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ console.log(myTextFile); // prints the contents of file.
 
 `browserify -t stringify myfile.js`
 
+### Browserify Command Line extension options ###
+
+`browserify -t [ stringify --extensions [.html .hbs] ] myfile.js`
+
 ### Browserify Middleware ###
 
 ```javascript

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -73,6 +73,9 @@ function getExtensions (options) {
     } else if (options.extensions) {
       extensions = options.extensions;
     }
+    else if( options.exts ) {
+      extensions = options.exts._;
+    }
   }
 
   // Lowercase all file extensions for case-insensitive matching.

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -71,10 +71,7 @@ function getExtensions (options) {
     if (Object.prototype.toString.call(options) === '[object Array]') {
       extensions = options;
     } else if (options.extensions) {
-      extensions = options.extensions;
-    }
-    else if( options.exts ) {
-      extensions = options.exts._;
+      extensions = options.extensions._;
     }
   }
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -70,8 +70,11 @@ function getExtensions (options) {
   if (options) {
     if (Object.prototype.toString.call(options) === '[object Array]') {
       extensions = options;
-    } else if (options.extensions) {
+    } else if (options.extensions && options.extensions) {
       extensions = options.extensions._;
+    }
+    else if(options.extensions) { 
+      extensions = options.extensions._
     }
   }
 


### PR DESCRIPTION
Dont take care of my previous pull request.

I urgently needed command line support

You can now use the command line tool with extensions options : 

browserify -t [ stringify --extensions [.html .hbs] ] -d src/scripts/ -o dist/js/bundle.js

Cheers