### PR TITLE
Add keyword "browserify-transform" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "website": "http://johnpostlethwait.github.com/stringify/",
   "keywords": [
     "browserify",
+    "browserify-transform",
     "require",
     "template",
     "text",


### PR DESCRIPTION
Whilst node-browserify has a [List of transforms](https://github.com/substack/node-browserify/wiki/list-of-transforms) that references stringify, it also states:

> You should also consult the [packages on npm with the browserify-transform tag](https://npmjs.org/browse/keyword/browserify-transform).

So why not add the keyword "browserify-transform" to <kbd>package.json</kbd>.