### PR TITLE
Add exportAsEs6Default option that allows to use exports.default

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ stringify({
 })
 ```
 
+### Export format ###
+By default HTML is exported with ```module.exports```, but you can use ```exportAsEs6Default``` flag to export it as ES6 default export (via ```exports.default```).
+
+```javascript
+stringify({
+  appliesTo: { includeExtensions: ['.txt', '.html'] },
+  exportAsEs6Default: true
+})
+```
+
 ## Realistic Example/Use-Case ##
 
 The reason I created this was to get string versions of my Handlebars templates

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "Sébastien David <sebastien.david.1983@gmail.com>",
     "Kenneth Skovhus <kenneth.skovhus@gmail.com>",
     "Michaelangelo Jong <mike96angelo@gmail.com>",
-    "Matthew Dunsdon <matthewdunsdon@gmail.com>"
+    "Matthew Dunsdon <matthewdunsdon@gmail.com>",
+    "NeverwinterMoon <manni.calavera@gmail.com>"
   ],
   "website": "http://johnpostlethwait.github.com/stringify/",
   "keywords": [

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -50,11 +50,14 @@ var NODE_REQUIRE_OPTIONS = {};
 
 /**
  * Stringifies the content
- * @param   {string}    content
+ * @param {string} content
+ * @param {boolean} exportAsEs6Default
  * @returns {string}
  */
-function stringify (content) {
-  return 'module.exports = ' + JSON.stringify(content) + ';\n';
+function stringify (content, exportAsEs6Default) {
+  var exportsString = exportAsEs6Default? 'exports.default' : 'module.exports';
+
+  return exportsString + ' = ' + JSON.stringify(content) + ';\n';
 }
 
 /**
@@ -197,7 +200,7 @@ function registerWithRequire (options) {
  * - `done(err, transformed)` is a callback which must be called, passing a
  *   string with the transformed contents of the file.
  *
- * @param  {string} content
+ * @param  {string} contents
  * @param  {object} transformOptions
  * @param  {function} done
  * @returns {void}
@@ -206,7 +209,7 @@ function transformFn (contents, transformOptions, done) {
   var file = transformOptions.file,
       options = transformOptions.config;
 
-  done(null, stringify(minify(file, contents, options)));
+  done(null, stringify(minify(file, contents, options), options.exportAsEs6Default));
 }
 
 /**

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -55,7 +55,8 @@ var NODE_REQUIRE_OPTIONS = {};
  * @returns {string}
  */
 function stringify (content, exportAsEs6Default) {
-  var exportsString = exportAsEs6Default? 'exports.default' : 'module.exports';
+  var exportsString = exportAsEs6Default ? 'Object.defineProperty(exports, "__esModule", { value: true });\n' +
+  'exports.default' : 'module.exports';
 
   return exportsString + ' = ' + JSON.stringify(content) + ';\n';
 }

--- a/test/stringify.spec.js
+++ b/test/stringify.spec.js
@@ -8,24 +8,39 @@ describe('the "stringify" function', function () {
   before(function () {
     this.test_string = '<html><head></head><body><h1 class="bananas" title="donkies">' +
       'This is my test string HTML!</h1></body></html>';
-
-    this.stringified_content = Stringify.stringify(this.test_string);
   });
 
-  it('should have returned a string', function () {
-    this.stringified_content.should.be.a.String;
+  describe('called with no XXX (default)', function () {
+    before(function () {
+      this.stringified_content = Stringify.stringify(this.test_string);
+    });
+
+    it('should have returned a string', function () {
+      this.stringified_content.should.be.a.String;
+    });
+
+    it('should begin with module.exports = "', function () {
+      this.stringified_content.should.startWith('module.exports = "');
+    });
+
+    // TODO: Figure out how to do a capture-repeat Regex for this to actually ensure all 5 newlines were preserved.
+    it('should have perserved newline characters', function () {
+      this.stringified_content.should.match(/\n/);
+    });
+
+    it('should have escaped the double-quotes', function () {
+      this.stringified_content.should.match(/\\\"/);
+    });
   });
 
-  it('should begin with module.exports = "', function () {
-    this.stringified_content.should.startWith('module.exports = "');
-  });
+  describe('called with exportAsEs6Default: true option', function () {
+    before(function () {
+      this.stringified_content = Stringify.stringify(this.test_string, true);
+    });
 
-  // TODO: Figure out how to do a capture-repeat Regex for this to actually ensure all 5 newlines were preserved.
-  it('should have perserved newline characters', function () {
-    this.stringified_content.should.match(/\n/);
-  });
-
-  it('should have escaped the double-quotes', function () {
-    this.stringified_content.should.match(/\\\"/);
+    it('should begin with module.default = "', function () {
+      console.log(this.stringified_content);
+      this.stringified_content.should.startWith('exports.default = "');
+    });
   });
 });

--- a/test/stringify.spec.js
+++ b/test/stringify.spec.js
@@ -10,7 +10,7 @@ describe('the "stringify" function', function () {
       'This is my test string HTML!</h1></body></html>';
   });
 
-  describe('called with no XXX (default)', function () {
+  describe('called without exportAsEs6Default option (default)', function () {
     before(function () {
       this.stringified_content = Stringify.stringify(this.test_string);
     });

--- a/test/stringify.spec.js
+++ b/test/stringify.spec.js
@@ -39,8 +39,8 @@ describe('the "stringify" function', function () {
     });
 
     it('should begin with module.default = "', function () {
-      console.log(this.stringified_content);
-      this.stringified_content.should.startWith('exports.default = "');
+      this.stringified_content.should.startWith(
+        'Object.defineProperty(exports, "__esModule", { value: true });\nexports.default = "');
     });
   });
 });


### PR DESCRIPTION
This is similar to webpack/html-loader option for exactly the same purpose.
(https://github.com/webpack/html-loader/pull/97/files)

When using TypeScript imports, this allows to write

import bla from './bla.html' (won't work without exports.default)
vs 
import * as bla from './bla.html'