### PR TITLE
Added support for minifier options to set from the cli

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -124,7 +124,12 @@ function getMinifyOptions (options) {
   }
 
   if (options.minifyOptions) {
-    minify.options = options.minifyOptions;
+    for (var opt in options.minifyOptions) {
+      if (typeof minify.options[opt] === 'boolean') { // the flag needs to be an existing default
+        // accomadate the fact that a string value for the flag comes from the cli
+        minify.options[opt] = options.minifyOptions[opt] === 'true' || options.minifyOptions[opt] === true;
+      }
+    }
   } else if (minifierOpts && minifierOpts.options) {
     minify.options = minifierOpts.options;
   }


### PR DESCRIPTION
I've added code that merges minifier options rather than overwrite as well as iterate over flags setting as a boolean. The result is that I can now pass minifier options using the cli as per the following example:
 
`watchify -vd -e src/App.ts -p [ tsify ] -t [ stringify --extensions [.html] --minify true --minifyOptions [ --removeAttributeQuotes false ] ]`